### PR TITLE
remove namespacing

### DIFF
--- a/mdx_truly_sane_lists/__init__.py
+++ b/mdx_truly_sane_lists/__init__.py
@@ -1,3 +1,3 @@
-from mdx_truly_sane_lists.mdx_truly_sane_lists import makeExtension
+from .mdx_truly_sane_lists import makeExtension
 
 assert makeExtension


### PR DESCRIPTION
required to work with Python 2