### PR TITLE
Update markdown version inspection with 3.4

### DIFF
--- a/mdx_truly_sane_lists/mdx_truly_sane_lists.py
+++ b/mdx_truly_sane_lists/mdx_truly_sane_lists.py
@@ -5,7 +5,12 @@ https://github.com/radude/mdx_truly_sane_lists
 import re
 
 from markdown import Extension, util
-from markdown import version as md_version
+try:
+    # markdown<3.4
+    from markdown import version as md_version
+except ImportError:
+    # markdown>=3.4
+    from markdown.__meta__ import __version__ as md_version
 from markdown.blockprocessors import OListProcessor, ListIndentProcessor, BlockProcessor
 
 


### PR DESCRIPTION
markdown moved the location of the version metadata in 3.4

Closes: #11 