### PR TITLE
fix: version deprecation warning from markdown

### DIFF
--- a/mdx_truly_sane_lists/mdx_truly_sane_lists.py
+++ b/mdx_truly_sane_lists/mdx_truly_sane_lists.py
@@ -7,7 +7,7 @@ import re
 from markdown import Extension
 try:
     # markdown<3.4
-    from markdown import version as md_version
+    from markdown import __version__ as md_version
 except ImportError:
     # markdown>=3.4
     from markdown.__meta__ import __version__ as md_version


### PR DESCRIPTION
Closing #18
Fix of `version` imported from `markdown` which gives the deprecation warning.

Can you have a look here @radude for a review and get rid of this annoying deprecation warning ?